### PR TITLE
File paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Version 1.1.0
+-------------
+**2018-05-17**
+
+* Adds helper container class for keeping track of file paths relative to some
+  mount point
+
 Version 1.0.0
 -------------
 

--- a/cml_pipelines/__init__.py
+++ b/cml_pipelines/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from .wrapper import task, make_task
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 version_info = namedtuple("VersionInfo", "major,minor,patch")(*__version__.split('.'))
 
 logger = logging.getLogger("cml.pipelines")

--- a/cml_pipelines/paths.py
+++ b/cml_pipelines/paths.py
@@ -1,0 +1,35 @@
+import os
+
+
+class FilePaths(object):
+    """ Paths to files that frequently get passed around to many tasks.
+
+        All paths given relative to the root path but are converted to absolute
+        paths on creation.
+
+    Parameters
+    ----------
+    root: str
+        Root directory, usually the mount point for RHINO
+
+    Notes
+    -----
+    All keyword arguments are converted into absolute paths relative to the
+    given root directory
+
+    """
+
+    def __init__(self, root, **kwargs):
+        self.root = os.path.expanduser(root)
+
+        self._keys = []
+        for key, val in kwargs.items():
+            stripped_val = val.lstrip('/').rstrip('/')
+            abs_path = os.path.join(self.root, stripped_val)
+            setattr(self, key, abs_path)
+            self._keys.append(key)
+
+    def keys(self):
+        """ List of file path keys that have been defined """
+        return self._keys
+

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   git_url: ../
-  # git_rev: {{ 'v' + setup_data['version'] }}  # always use tagged version
+  git_rev: {{ 'v' + setup_data['version'] }}  # always use tagged version
 
 build:
   # If this is a new build for the same version, increment the build

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+from cml_pipelines.paths import FilePaths
+
+
+class TestFilePaths:
+    @classmethod
+    def setup_class(cls):
+        cls.test_paths = FilePaths("/mnt/mount_point/", dir1="/base/",
+                                   dir2="dir2/")
+
+    @pytest.mark.parametrize("basedir", ["basedir", "/basedir", "/basedir/"])
+    @pytest.mark.parametrize("root", ["/", "~", "mount_point/", "/mount_point/"])
+    def test_initialize(self, root, basedir):
+        paths = FilePaths(root, base=basedir)
+
+        basedir = basedir.lstrip("/").rstrip("/")
+
+        assert paths.root == os.path.expanduser(root)
+        assert paths.base == os.path.join(os.path.expanduser(root), basedir)
+        return
+
+    def test_keys(self):
+        keys = self.test_paths.keys()
+        assert len(keys) == 2
+        assert keys[0] == "dir1"
+        assert keys[1] == "dir2"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -23,5 +23,5 @@ class TestFilePaths:
     def test_keys(self):
         keys = self.test_paths.keys()
         assert len(keys) == 2
-        assert keys[0] == "dir1"
-        assert keys[1] == "dir2"
+        assert "dir1" in keys
+        assert "dir2" in keys


### PR DESCRIPTION
Adds a version of the FilePaths container class originally used in ramutils. I opted to use a simple class rather than sub-classing dict or using attrdict or something similar since those were doing way more than was actually needed.